### PR TITLE
auto `released` plugin test

### DIFF
--- a/auto.config.cts
+++ b/auto.config.cts
@@ -2,6 +2,6 @@ import type { AutoRc } from 'auto';
 
 export default function rc(): AutoRc {
   return {
-    plugins: ['npm', 'all-contributors', 'first-time-contributor', 'released'],
+    plugins: ['npm', 'released', 'all-contributors', 'first-time-contributor'],
   };
 }


### PR DESCRIPTION
## Description

Now, `released` not working...
The order of plugins may have something to do with it.

<!--
## Release Notes

If this PR title is just not enough to capture what a user should know about this PR, you can put extra release notes.
-->
